### PR TITLE
Add Dependabot config for Bundler (weekly, grouped)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: "bundler"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      rails:
+        patterns:
+          - "rails*"
+          - "actionpack"
+          - "actionview"
+          - "activesupport"
+          - "railties"
+      mongoid:
+        patterns:
+          - "mongoid*"
+          - "kaminari*"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to re-enable Dependabot, which had stopped running due to a missing config file
- Monitors **Bundler only** — `npm_and_yarn` was removed since the project migrated to `importmap-rails` in the Rails 8 upgrade
- Weekly schedule (Monday), max 5 open PRs, Rails and Mongoid updates grouped to reduce PR noise

## Related cleanup

27 stale Dependabot PRs were closed before this PR:
- 20 `npm_and_yarn` PRs: obsolete, no `package.json` in the repo anymore
- 7 `bundler` PRs: superseded by the Rails 8 upgrade (`Gemfile.lock` already has much newer versions)

## Test plan

- [ ] Confirm `.github/dependabot.yml` is valid YAML and passes GitHub's schema check
- [ ] Verify Dependabot activates on the next Monday after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)