### PR TITLE
Style Kaminari paginator with Bootstrap 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,11 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+      selenium:
+        image: selenium/standalone-chrome
+        options: --shm-size=2g
+        ports:
+          - 4444:4444
 
     env:
       RAILS_ENV: test
@@ -39,3 +44,9 @@ jobs:
 
       - name: Run tests
         run: bundle exec rails test
+
+      - name: Run system tests
+        run: bundle exec rails test:system
+        env:
+          SELENIUM_REMOTE_URL: http://localhost:4444
+          APP_HOST: localhost

--- a/README.md
+++ b/README.md
@@ -1,25 +1,69 @@
-# README
 # password-manager
-Small application for managing your hundreds of passwords without give them to any external providers...
 
-Things you may want to cover:
+Small Rails application for managing passwords locally, without handing them to any external provider.
 
-* Docker configuration
+## Requirements
 
-* Ruby version
+- Docker + Docker Compose
+- No local Ruby installation needed — everything runs inside containers
 
-* System dependencies
+## Configuration
 
-* Configuration
+Copy `.env.example` to `.env` and fill in the required values (MongoDB credentials, secret key base, etc.).
 
-* Database creation
+## Running the application
 
-* Database initialization
+```bash
+docker compose up -d mongo
+docker compose up passwordmanager
+```
 
-* How to run the test suite
+The app will be available at http://localhost:3000.
 
-* Services (job queues, cache servers, search engines, etc.)
+## Running the test suite
 
-* Deployment instructions
+### Unit and integration tests
 
-* ...
+```bash
+docker compose run --rm passwordmanager rails test
+```
+
+No extra services needed — these tests use the MongoDB container only.
+
+### System tests (browser-based)
+
+System tests drive a real browser via Selenium. Start the required services first, then run:
+
+```bash
+# Start MongoDB and the Selenium browser container
+docker compose up -d mongo selenium
+
+# Run system tests
+docker compose run --rm \
+  -e SELENIUM_REMOTE_URL=http://selenium:4444 \
+  -e APP_HOST=passwordmanager-test \
+  passwordmanager-test \
+  rails test:system
+```
+
+Screenshots of any failing tests are saved to `tmp/screenshots/`.
+
+### All tests at once
+
+```bash
+docker compose up -d mongo selenium
+docker compose run --rm passwordmanager rails test
+docker compose run --rm \
+  -e SELENIUM_REMOTE_URL=http://selenium:4444 \
+  -e APP_HOST=passwordmanager-test \
+  passwordmanager-test \
+  rails test:system
+```
+
+## Running generators and other Rails commands
+
+Always run generators inside the container so the output lands in the mounted volume:
+
+```bash
+docker compose run --rm passwordmanager rails generate <generator> <args>
+```

--- a/app/views/credentials/index.html.erb
+++ b/app/views/credentials/index.html.erb
@@ -39,9 +39,10 @@
   </tbody>
 </table>
 
-<%= paginate @credentials %>
-
-<br />
+<div class="d-flex flex-column align-items-center my-3">
+  <span class="text-muted small mb-1"><%= page_entries_info @credentials %></span>
+  <%= paginate @credentials %>
+</div>
 <div class="btn-group" role="group" aria-label="Strumenti">
   <%= link_to 'Nuova Credenziale', new_credential_path, class: "btn btn-primary" %>
   <%= link_to 'Home', welcome_path, class: "btn btn-primary" %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.first'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -1,0 +1,3 @@
+<li class='page-item disabled'>
+  <%= link_to raw(t 'views.pagination.truncate'), '#', class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.last'), url, remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.last?, raw(t 'views.pagination.next'), url, rel: 'next', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,0 +1,9 @@
+<% if page.current? %>
+  <li class="page-item active">
+    <%= content_tag :a, page, data: { remote: remote }, rel: page.rel, class: 'page-link' %>
+  </li>
+<% else %>
+  <li class="page-item">
+    <%= link_to page, url, remote: remote, rel: page.rel, class: 'page-link' %>
+  </li>
+<% end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -1,0 +1,17 @@
+<%= paginator.render do %>
+  <nav>
+    <ul class="pagination pagination-sm">
+      <%= first_page_tag unless current_page.first? %>
+      <%= prev_page_tag unless current_page.first? %>
+      <% each_page do |page| %>
+        <% if page.left_outer? || page.right_outer? || page.inside_window? %>
+          <%= page_tag page %>
+        <% elsif !page.was_truncated? -%>
+          <%= gap_tag %>
+        <% end %>
+      <% end %>
+      <%= next_page_tag unless current_page.last? %>
+      <%= last_page_tag unless current_page.last? %>
+    </ul>
+  </nav>
+<% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -1,0 +1,3 @@
+<li class="page-item">
+  <%= link_to_unless current_page.first?, raw(t 'views.pagination.previous'), url, rel: 'prev', remote: remote, class: 'page-link' %>
+</li>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -26,5 +26,10 @@
     <%= form.password_field :password, class: "form-control" %>
   </div>
 
+  <div class="form-group">
+    <%= form.label :password_confirmation %>
+    <%= form.password_field :password_confirmation, class: "form-control" %>
+  </div>
+
   <%= form.submit class: "btn btn-primary" %>
 <% end %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -22,10 +22,10 @@
   </tbody>
 </table>
 
-<br>
-
-<%= paginate @users %>
-<br />
+<div class="d-flex flex-column align-items-center my-3">
+  <span class="text-muted small mb-1"><%= page_entries_info @users %></span>
+  <%= paginate @users %>
+</div>
 <div class="btn-group" role="group" aria-label="Strumenti">
   <%= link_to 'Nuovo Utente', new_user_path, class: "btn btn-primary" %>
   <%= link_to 'Home', welcome_path, class: "btn btn-primary" %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -16,7 +16,7 @@
         <td><%= user.email %></td>
         <td><%= link_to 'Visualizza', user %></td>
         <td><%= link_to 'Modifica', edit_user_path(user) %></td>
-        <td><%= link_to 'Cancella', user, method: :delete, data: { confirm: 'Sei sicuro?' } %></td>
+        <td><%= link_to 'Cancella', user, data: { turbo_method: :delete, turbo_confirm: 'Sei sicuro?' } %></td>
       </tr>
     <% end %>
   </tbody>

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,6 @@ module PasswordManager
     config.load_defaults 8.0
 
     config.autoload_paths += %W[#{config.root}/app/field_type]
+    config.i18n.default_locale = :it
   end
 end

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -1,0 +1,25 @@
+it:
+  mongoid:
+    models:
+      credential:
+        one: credenziale
+        other: credenziali
+      user:
+        one: utente
+        other: utenti
+  views:
+    pagination:
+      first: "&laquo; Prima"
+      last: "Ultima &raquo;"
+      previous: "&lsaquo; Precedente"
+      next: "Successiva &rsaquo;"
+      truncate: "&hellip;"
+  helpers:
+    page_entries_info:
+      one_page:
+        display_entries:
+          zero: "Nessun %{entry_name} trovato"
+          one: "Visualizzando <b>1</b> %{entry_name}"
+          other: "Visualizzando <b>tutti e %{count}</b> %{entry_name}"
+      more_pages:
+        display_entries: "Visualizzando %{entry_name} <b>%{first}&nbsp;&ndash;&nbsp;%{last}</b> di <b>%{total}</b>"

--- a/config/locales/it.yml
+++ b/config/locales/it.yml
@@ -7,6 +7,14 @@ it:
       user:
         one: utente
         other: utenti
+  errors:
+    messages:
+      blank: "non può essere vuoto"
+      taken: "è già stato preso"
+      too_short:
+        one: "è troppo corto (minimo 1 carattere)"
+        other: "è troppo corto (minimo %{count} caratteri)"
+      invalid: "non è valido"
   views:
     pagination:
       first: "&laquo; Prima"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,12 @@ services:
     links:
       - mongo
 
+  selenium:
+    image: seleniarm/standalone-chromium
+    shm_size: 2g
+    ports:
+      - 4444:4444
+
   passwordmanager:
     build:
       context: .
@@ -37,6 +43,23 @@ services:
       - .env
     ports:
       - 3000:3000
+
+  passwordmanager-test:
+    build:
+      context: .
+      args:
+        ZSCALER_CERT: ${ZSCALER_CERT:-}
+    environment:
+      RAILS_ENV: test
+      SELENIUM_REMOTE_URL: http://selenium:4444
+      APP_HOST: passwordmanager-test
+    links:
+      - mongo
+      - selenium
+    volumes:
+      - .:/password-manager
+    env_file:
+      - .env
 
 volumes:
   mongodb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.5'
-
 services:
   mongo:
     image: mongo

--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -1,5 +1,19 @@
 require "test_helper"
+require "socket"
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  if ENV["SELENIUM_REMOTE_URL"]
+    HOST_IP = Socket.ip_address_list.select(&:ipv4?).reject(&:ipv4_loopback?).first.ip_address
+
+    Capybara.server_host = HOST_IP
+    Capybara.server_port = 3001
+    Capybara.app_host   = "http://#{HOST_IP}:3001"
+
+    driven_by :selenium, using: :chrome, screen_size: [1400, 1400], options: {
+      browser: :remote,
+      url: ENV["SELENIUM_REMOTE_URL"]
+    }
+  else
+    driven_by :selenium, using: :headless_chrome, screen_size: [1400, 1400]
+  end
 end

--- a/test/controllers/credentials_controller_test.rb
+++ b/test/controllers/credentials_controller_test.rb
@@ -54,4 +54,25 @@ class CredentialsControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to credentials_url
   end
+
+  test "index shows page 1 as active in paginator" do
+    26.times { |i| Credential.create!(name: "Cred #{i}", username: "u", password: "p", url: "https://x.com", note: "", user: @user) }
+    get credentials_url
+    assert_response :success
+    assert_select "li.page-item.active a.page-link", text: "1"
+  end
+
+  test "index shows page 2 as active when requested" do
+    26.times { |i| Credential.create!(name: "Cred #{i}", username: "u", password: "p", url: "https://x.com", note: "", user: @user) }
+    get credentials_url, params: { page: 2 }
+    assert_response :success
+    assert_select "li.page-item.active a.page-link", text: "2"
+  end
+
+  test "index renders Bootstrap pagination markup" do
+    26.times { |i| Credential.create!(name: "Cred #{i}", username: "u", password: "p", url: "https://x.com", note: "", user: @user) }
+    get credentials_url
+    assert_select "ul.pagination"
+    assert_select "li.page-item"
+  end
 end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -49,4 +49,25 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     end
     assert_redirected_to users_url
   end
+
+  test "index shows page 1 as active in paginator" do
+    25.times { |i| User.create!(name: "User #{i}", email: "u#{i}@example.com", password: "password123", password_confirmation: "password123") }
+    get users_url
+    assert_response :success
+    assert_select "li.page-item.active a.page-link", text: "1"
+  end
+
+  test "index shows page 2 as active when requested" do
+    25.times { |i| User.create!(name: "User #{i}", email: "u#{i}@example.com", password: "password123", password_confirmation: "password123") }
+    get users_url, params: { page: 2 }
+    assert_response :success
+    assert_select "li.page-item.active a.page-link", text: "2"
+  end
+
+  test "index renders Bootstrap pagination markup" do
+    25.times { |i| User.create!(name: "User #{i}", email: "u#{i}@example.com", password: "password123", password_confirmation: "password123") }
+    get users_url
+    assert_select "ul.pagination"
+    assert_select "li.page-item"
+  end
 end

--- a/test/integration/pagination_test.rb
+++ b/test/integration/pagination_test.rb
@@ -1,0 +1,67 @@
+require "test_helper"
+
+class PaginationTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(name: "Test User", email: "test@example.com",
+                         password: "password123", password_confirmation: "password123")
+    post login_url, params: { email: @user.email, password: "password123" }
+  end
+
+  # --- Credentials ---
+
+  test "credentials: paginator hidden when records fit on one page" do
+    3.times { |i| Credential.create!(name: "C#{i}", username: "u", password: "p", url: "https://x.com", note: "", user: @user) }
+    get credentials_url
+    assert_select "ul.pagination", count: 0
+  end
+
+  test "credentials: Bootstrap paginator present on page 1 of 2" do
+    26.times { |i| Credential.create!(name: "Cred #{i}", username: "u", password: "p", url: "https://x.com", note: "", user: @user) }
+    get credentials_url
+    assert_select "ul.pagination.pagination-sm"
+    assert_select "li.page-item.active a.page-link", text: "1"
+  end
+
+  test "credentials: page 2 shows correct active page" do
+    26.times { |i| Credential.create!(name: "Cred #{i}", username: "u", password: "p", url: "https://x.com", note: "", user: @user) }
+    get credentials_url, params: { page: 2 }
+    assert_select "li.page-item.active a.page-link", text: "2"
+  end
+
+  test "credentials: page_entries_info label present in Italian" do
+    26.times { |i| Credential.create!(name: "Cred #{i}", username: "u", password: "p", url: "https://x.com", note: "", user: @user) }
+    get credentials_url
+    assert_select ".text-muted.small" do
+      assert_select "[class~=small]"
+    end
+    assert_match(/credenziali/, response.body)
+    assert_match(/Visualizzando/, response.body)
+  end
+
+  # --- Users ---
+
+  test "users: paginator hidden when records fit on one page" do
+    get users_url
+    assert_select "ul.pagination", count: 0
+  end
+
+  test "users: Bootstrap paginator present on page 1 of 2" do
+    25.times { |i| User.create!(name: "User #{i}", email: "u#{i}@example.com", password: "password123", password_confirmation: "password123") }
+    get users_url
+    assert_select "ul.pagination.pagination-sm"
+    assert_select "li.page-item.active a.page-link", text: "1"
+  end
+
+  test "users: page 2 shows correct active page" do
+    25.times { |i| User.create!(name: "User #{i}", email: "u#{i}@example.com", password: "password123", password_confirmation: "password123") }
+    get users_url, params: { page: 2 }
+    assert_select "li.page-item.active a.page-link", text: "2"
+  end
+
+  test "users: page_entries_info label present in Italian" do
+    25.times { |i| User.create!(name: "User #{i}", email: "u#{i}@example.com", password: "password123", password_confirmation: "password123") }
+    get users_url
+    assert_match(/utenti/, response.body)
+    assert_match(/Visualizzando/, response.body)
+  end
+end

--- a/test/models/credential_test.rb
+++ b/test/models/credential_test.rb
@@ -17,7 +17,7 @@ class CredentialTest < ActiveSupport::TestCase
     cred = Credential.new(username: 'alice', password: 'secret',
                           url: 'https://github.com', user: @user)
     assert_not cred.valid?
-    assert_includes cred.errors[:name], "can't be blank"
+    assert_includes cred.errors[:name], "non può essere vuoto"
   end
 
   test "requires user" do
@@ -30,7 +30,7 @@ class CredentialTest < ActiveSupport::TestCase
     cred = Credential.new(name: 'GitHub', password: 'secret',
                           url: 'https://github.com', user: @user)
     assert_not cred.valid?
-    assert_includes cred.errors[:username], "can't be blank"
+    assert_includes cred.errors[:username], "non può essere vuoto"
   end
 
   test "password is encrypted at rest" do

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -10,7 +10,7 @@ class UserTest < ActiveSupport::TestCase
   test "requires email" do
     user = User.new(name: 'Alice', password: 'password123', password_confirmation: 'password123')
     assert_not user.valid?
-    assert_includes user.errors[:email], "can't be blank"
+    assert_includes user.errors[:email], "non può essere vuoto"
   end
 
   test "requires password of at least 8 characters" do

--- a/test/system/credentials_test.rb
+++ b/test/system/credentials_test.rb
@@ -11,6 +11,7 @@ class CredentialsTest < ApplicationSystemTestCase
     fill_in "Email", with: @user.email
     fill_in "Password", with: "password123"
     click_on "Login"
+    assert_text "Benvenuto"
   end
 
   test "visiting the index" do
@@ -27,7 +28,7 @@ class CredentialsTest < ApplicationSystemTestCase
     fill_in "Password", with: "secret2"
     fill_in "Url", with: "https://gitlab.com"
     fill_in "Username", with: "testuser"
-    click_on "Create Credential"
+    find('[type="submit"]').click
 
     assert_text "Credential was successfully created"
   end
@@ -36,7 +37,7 @@ class CredentialsTest < ApplicationSystemTestCase
     visit edit_credential_url(@credential)
 
     fill_in "Name", with: "GitHub Updated"
-    click_on "Update Credential"
+    find('[type="submit"]').click
 
     assert_text "Credential was successfully updated"
   end

--- a/test/system/credentials_test.rb
+++ b/test/system/credentials_test.rb
@@ -2,48 +2,49 @@ require "application_system_test_case"
 
 class CredentialsTest < ApplicationSystemTestCase
   setup do
-    @credential = credentials(:one)
+    @user = User.create!(name: "Test User", email: "test@example.com",
+                         password: "password123", password_confirmation: "password123")
+    @credential = Credential.create!(name: "GitHub", username: "testuser",
+                                     password: "secret", url: "https://github.com",
+                                     note: "Personal account", user: @user)
+    visit login_url
+    fill_in "Email", with: @user.email
+    fill_in "Password", with: "password123"
+    click_on "Login"
   end
 
   test "visiting the index" do
     visit credentials_url
-    assert_selector "h1", text: "Credentials"
+    assert_selector "h1", text: "Credenziali"
   end
 
   test "creating a Credential" do
     visit credentials_url
-    click_on "New Credential"
+    click_on "Nuova Credenziale"
 
-    fill_in "Name", with: @credential.name
-    fill_in "Note", with: @credential.note
-    fill_in "Password", with: @credential.password
-    fill_in "Url", with: @credential.url
-    fill_in "Username", with: @credential.username
+    fill_in "Name", with: "GitLab"
+    fill_in "Note", with: ""
+    fill_in "Password", with: "secret2"
+    fill_in "Url", with: "https://gitlab.com"
+    fill_in "Username", with: "testuser"
     click_on "Create Credential"
 
     assert_text "Credential was successfully created"
-    click_on "Back"
   end
 
   test "updating a Credential" do
-    visit credentials_url
-    click_on "Edit", match: :first
+    visit edit_credential_url(@credential)
 
-    fill_in "Name", with: @credential.name
-    fill_in "Note", with: @credential.note
-    fill_in "Password", with: @credential.password
-    fill_in "Url", with: @credential.url
-    fill_in "Username", with: @credential.username
+    fill_in "Name", with: "GitHub Updated"
     click_on "Update Credential"
 
     assert_text "Credential was successfully updated"
-    click_on "Back"
   end
 
   test "destroying a Credential" do
     visit credentials_url
     page.accept_confirm do
-      click_on "Destroy", match: :first
+      click_on "Cancella", match: :first
     end
 
     assert_text "Credential was successfully destroyed"

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -2,44 +2,49 @@ require "application_system_test_case"
 
 class UsersTest < ApplicationSystemTestCase
   setup do
-    @user = users(:one)
+    @user = User.create!(name: "Test User", email: "test@example.com",
+                         password: "password123", password_confirmation: "password123")
+    visit login_url
+    fill_in "Email", with: @user.email
+    fill_in "Password", with: "password123"
+    click_on "Login"
   end
 
   test "visiting the index" do
     visit users_url
-    assert_selector "h1", text: "Users"
+    assert_selector "h1", text: "Utenti"
   end
 
   test "creating a User" do
     visit users_url
-    click_on "New User"
+    click_on "Nuovo Utente"
 
-    fill_in "Email", with: @user.email
-    fill_in "Name", with: @user.name
-    fill_in "Password", with: @user.password
+    fill_in "Email", with: "new@example.com"
+    fill_in "Name", with: "New User"
+    fill_in "Password", with: "password123"
+    fill_in "Password confirmation", with: "password123"
     click_on "Create User"
 
     assert_text "User was successfully created"
-    click_on "Back"
   end
 
   test "updating a User" do
-    visit users_url
-    click_on "Edit", match: :first
+    visit edit_user_url(@user)
 
-    fill_in "Email", with: @user.email
-    fill_in "Name", with: @user.name
-    fill_in "Password", with: @user.password
+    fill_in "Name", with: "Updated Name"
+    fill_in "Password", with: "password123"
+    fill_in "Password confirmation", with: "password123"
     click_on "Update User"
 
     assert_text "User was successfully updated"
-    click_on "Back"
   end
 
   test "destroying a User" do
+    extra = User.create!(name: "To Delete", email: "del@example.com",
+                         password: "password123", password_confirmation: "password123")
     visit users_url
     page.accept_confirm do
-      click_on "Destroy", match: :first
+      click_on "Cancella", match: :first
     end
 
     assert_text "User was successfully destroyed"

--- a/test/system/users_test.rb
+++ b/test/system/users_test.rb
@@ -8,6 +8,7 @@ class UsersTest < ApplicationSystemTestCase
     fill_in "Email", with: @user.email
     fill_in "Password", with: "password123"
     click_on "Login"
+    assert_text "Benvenuto"
   end
 
   test "visiting the index" do
@@ -23,7 +24,7 @@ class UsersTest < ApplicationSystemTestCase
     fill_in "Name", with: "New User"
     fill_in "Password", with: "password123"
     fill_in "Password confirmation", with: "password123"
-    click_on "Create User"
+    find('[type="submit"]').click
 
     assert_text "User was successfully created"
   end
@@ -34,7 +35,7 @@ class UsersTest < ApplicationSystemTestCase
     fill_in "Name", with: "Updated Name"
     fill_in "Password", with: "password123"
     fill_in "Password confirmation", with: "password123"
-    click_on "Update User"
+    find('[type="submit"]').click
 
     assert_text "User was successfully updated"
   end


### PR DESCRIPTION
## Summary

- Generates Kaminari Bootstrap 4 view templates (HTML structure identical to Bootstrap 5) under \`app/views/kaminari/\`
- Adds \`pagination-sm\` class for a compact control consistent with the table rows
- Wraps \`paginate\` calls in a centred flex column with a \`page_entries_info\` label above the paginator, in both \`credentials/index\` and \`users/index\`
- Introduces \`config/locales/it.yml\` with Kaminari link labels (Prima, Ultima, Precedente, Successiva), Italian error messages, and Mongoid model name translations (\`credenziale/credenziali\`, \`utente/utenti\`)
- Sets \`config.i18n.default_locale = :it\` in \`application.rb\`
- Removes obsolete \`version\` key from \`docker-compose.yml\`
- Adds \`password_confirmation\` field to the users form (missing from original scaffold)
- Fixes users destroy link to use \`data-turbo-confirm\` instead of deprecated Rails UJS \`data-confirm\`

Closes #53

## System test infrastructure

- Adds \`seleniarm/standalone-chromium\` service to \`docker-compose.yml\` (ARM64-compatible) and a dedicated \`passwordmanager-test\` service with \`SELENIUM_REMOTE_URL\` pre-configured
- \`ApplicationSystemTestCase\` detects \`SELENIUM_REMOTE_URL\` at load time: uses a remote Chrome driver pointed at the container and resolves the Puma server address via \`Socket.ip_address_list\` (bypasses Docker DNS which is unreliable with \`docker compose run\`); falls back to local headless Chrome when the variable is absent
- Fixes Turbo Drive async login race: adds \`assert_text "Benvenuto"\` after \`click_on "Login"\` to synchronise before navigating to protected routes
- CI (\`.github/workflows/ci.yml\`): adds \`selenium/standalone-chrome\` service container and a \`rails test:system\` step — **system tests run automatically on every push and every pull request**

## Tests added

- **Controller tests** (\`test/controllers/\`): Bootstrap markup present, active page indicator correct on page 1 and page 2 — for both Credential and User
- **Integration tests** (\`test/integration/pagination_test.rb\`): paginator hidden on single page, Bootstrap classes present across pages, Italian \`page_entries_info\` label — rack_test, no browser required
- **System tests** (\`test/system/\`): full browser smoke tests for index, create, update, and destroy on both Credential and User — 8 tests, all green

## Test plan

- [ ] `docker compose run --rm passwordmanager rails test` — 45 tests pass
- [ ] System tests locally:
  ```
  docker compose up -d mongo selenium
  docker compose run --rm \
    -e SELENIUM_REMOTE_URL=http://selenium:4444 \
    -e APP_HOST=passwordmanager-test \
    passwordmanager-test \
    rails test:system
  ```
  8 tests pass
- [ ] `docker compose up` — navigate to `/credentials` with 30+ records, verify Bootstrap-styled paginator appears centred with Italian labels and info text
- [ ] Navigate to page 2 and back, verify prev/next links work and show Italian labels
- [ ] Navigate to `/users` — verify same layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)