### PR TITLE
Mask password field in form with show/hide toggle (issue #52)

### DIFF
--- a/app/javascript/controllers/clipboard_controller.js
+++ b/app/javascript/controllers/clipboard_controller.js
@@ -19,6 +19,7 @@ export default class extends Controller {
   }
 
   #write(text) {
+    if (!navigator.clipboard) { this.#flash("🚫"); return }
     navigator.clipboard.writeText(text).then(() => {
       this.#flash("✓")
       setTimeout(() => navigator.clipboard.writeText(""), this.clearAfterValue)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -1,4 +1,6 @@
 import { application } from "controllers/application"
 import ClipboardController from "controllers/clipboard_controller"
+import PasswordToggleController from "controllers/password_toggle_controller"
 
 application.register("clipboard", ClipboardController)
+application.register("password-toggle", PasswordToggleController)

--- a/app/javascript/controllers/password_toggle_controller.js
+++ b/app/javascript/controllers/password_toggle_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = ["field", "icon"]
+
+  toggle() {
+    const isPassword = this.fieldTarget.type === "password"
+    this.fieldTarget.type = isPassword ? "text" : "password"
+    this.iconTarget.classList.toggle("bi-eye", !isPassword)
+    this.iconTarget.classList.toggle("bi-eye-slash", isPassword)
+  }
+}

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -20,8 +20,4 @@ class Credential
   validates_presence_of :password
   validates_presence_of :url
 
-  def password_before_type_cast
-    password
-  end
-
 end

--- a/app/views/credentials/_form.html.erb
+++ b/app/views/credentials/_form.html.erb
@@ -23,7 +23,18 @@
 
   <div class="form-group">
     <%= form.label :password %>
-    <%= form.text_field :password, class: "form-control" %>
+    <div class="input-group" data-controller="password-toggle">
+      <%= form.password_field :password,
+            class: "form-control",
+            id: "credential_password",
+            value: form.object.password,
+            data: { "password-toggle-target": "field" } %>
+      <button class="btn btn-outline-secondary" type="button"
+              data-action="click->password-toggle#toggle"
+              aria-label="Mostra/nascondi password">
+        <i class="bi bi-eye" data-password-toggle-target="icon"></i>
+      </button>
+    </div>
   </div>
 
   <div class="form-group">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,6 +6,7 @@
     <%= csp_meta_tag %>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/bootstrap-icons.min.css" rel="stylesheet">
     <%= stylesheet_link_tag 'application', media: 'all' %>
     <%= javascript_importmap_tags %>
   </head>

--- a/test/system/credentials_test.rb
+++ b/test/system/credentials_test.rb
@@ -153,4 +153,18 @@ class CredentialsTest < ApplicationSystemTestCase
     assert_selector '[aria-label="Copia password"]', text: "🚫"
     assert_no_selector '[aria-label="Copia password"]', text: "🚫", wait: 5
   end
+
+  test "password field is masked by default in edit form" do
+    visit edit_credential_url(@credential)
+    assert_equal "password", find("#credential_password")[:type]
+  end
+
+  test "toggle button reveals and re-masks password in edit form" do
+    visit edit_credential_url(@credential)
+    find('[aria-label="Mostra/nascondi password"]').click
+    assert_equal "text", find("#credential_password")[:type]
+
+    find('[aria-label="Mostra/nascondi password"]').click
+    assert_equal "password", find("#credential_password")[:type]
+  end
 end


### PR DESCRIPTION
## Summary

- Changes the password input in the create/edit form from `text_field` (plaintext) to `password_field` with an explicit `value:` pre-fill so the edit form correctly shows the existing password masked
- Adds a Stimulus `password-toggle` controller that switches the input type between `password` and `text` and swaps the Bootstrap Icon between `bi-eye` and `bi-eye-slash`
- Adds Bootstrap Icons CDN to the layout (already used by Bootstrap 5)
- Guards `navigator.clipboard` availability before write to avoid a silent `TypeError` on HTTP origins (code review finding)
- Removes unused `password_before_type_cast` dead code from `Credential` model (code review finding)

## Test plan

- [ ] System tests pass: `docker compose run --rm -e SELENIUM_REMOTE_URL=http://selenium:4444 -e APP_HOST=passwordmanager-test passwordmanager-test rails test test/system/credentials_test.rb` (14 runs, 0 failures)
- [ ] Controller tests pass: 16 runs, 0 failures
- [ ] Edit form shows password masked by default
- [ ] Toggle button reveals / re-masks the password
- [ ] Saving without changing password preserves the existing value

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)