### PR TITLE
feat: Api::SessionsController — login/logout + rack-attack (story C, closes #63)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'stimulus-rails'
 gem 'propshaft'
 
 gem 'bootsnap', require: false
+gem 'rack-attack'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -192,6 +192,8 @@ GEM
       nio4r (~> 2.0)
     racc (1.8.1)
     rack (3.2.6)
+    rack-attack (6.8.0)
+      rack (>= 1.0, < 4)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -288,6 +290,7 @@ DEPENDENCIES
   mongoid (~> 9.0)
   propshaft
   puma (~> 6.0)
+  rack-attack
   rails (~> 8.0)
   selenium-webdriver (~> 4.0)
   stimulus-rails

--- a/app/controllers/api/sessions_controller.rb
+++ b/app/controllers/api/sessions_controller.rb
@@ -1,0 +1,24 @@
+module Api
+  class SessionsController < ActionController::API
+    def create
+      user = User.where(email: params[:email]).first
+      unless user&.authenticate(params[:password])
+        return render json: { error: "Invalid email or password" }, status: :unauthorized
+      end
+
+      api_token = ApiToken.generate_for(user)
+      render json: { token: api_token.token, expires_at: api_token.expires_at.iso8601 },
+             status: :created
+    end
+
+    def destroy
+      api_token = ApiToken.where(token: params[:token]).first
+      unless api_token
+        return render json: { error: "Token not found" }, status: :not_found
+      end
+
+      api_token.destroy
+      head :no_content
+    end
+  end
+end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,5 +1,12 @@
+Rack::Attack.cache.store = ActiveSupport::Cache::MemoryStore.new
+
 class Rack::Attack
   throttle("api/sessions", limit: 5, period: 60) do |req|
     req.ip if req.post? && req.path == "/api/sessions"
+  end
+
+  self.throttled_responder = lambda do |_env|
+    [429, { "Content-Type" => "application/json" },
+     [{ error: "Too many requests. Retry in a minute." }.to_json]]
   end
 end

--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,0 +1,5 @@
+class Rack::Attack
+  throttle("api/sessions", limit: 5, period: 60) do |req|
+    req.ip if req.post? && req.path == "/api/sessions"
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   namespace :api do
-    # Story C: Api::SessionsController (login/logout)
+    resources :sessions, only: [:create, :destroy], param: :token
     # Story D: Api::CredentialsController (index, create)
   end
 

--- a/docs/adr/browser-extension.md
+++ b/docs/adr/browser-extension.md
@@ -126,18 +126,18 @@ Token expiry
 
 Le seguenti issue vanno lavorate in ordine — ogni step è prerequisito del successivo.
 
-| # | Storia | Dipende da |
-|---|---|---|
-| A | ~~HTTPS/TLS setup~~ _(non necessario: dominio pubblico con HTTPS)_ | — |
-| B | Rails API layer: `ApiToken` model + `Api::BaseController` + token auth | — |
-| C | Rails API: `Api::SessionsController` (login/logout) + `rack-attack` | B |
-| D | Rails API: `Api::CredentialsController` (index per domain, create) + `rack-cors` | B |
-| E | Browser extension: content script (capture + save prompt) | C, D |
-| F | Browser extension: background service worker (token management, API calls, URL configurabile) | C, D |
-| G | Browser extension: options page (URL base configurabile, salvataggio in `chrome.storage.sync`) | — |
-| H | Browser extension: popup (credential list, fill trigger, login/logout) | E, F, G |
-| I | Web app: banner/suggerimento installazione extension | — |
-| J | `.dockerignore`: escludere `extension/` e `docs/` dall'immagine Docker | — |
+| # | Storia | Issue | Dipende da |
+|---|---|---|---|
+| A | ~~HTTPS/TLS setup~~ _(non necessario: dominio pubblico con HTTPS)_ | [#61](https://github.com/alkcxy/password-manager/issues/61) | — |
+| B | ~~Rails API layer: `ApiToken` model + `Api::BaseController` + token auth~~ | [#62](https://github.com/alkcxy/password-manager/issues/62) | — |
+| C | Rails API: `Api::SessionsController` (login/logout) + `rack-attack` | [#63](https://github.com/alkcxy/password-manager/issues/63) | B |
+| D | Rails API: `Api::CredentialsController` (index per domain, create) + `rack-cors` | [#64](https://github.com/alkcxy/password-manager/issues/64) | B |
+| E | Browser extension: content script (capture + save prompt) | [#65](https://github.com/alkcxy/password-manager/issues/65) | C, D |
+| F | Browser extension: background service worker (token management, API calls, URL configurabile) | [#66](https://github.com/alkcxy/password-manager/issues/66) | C, D |
+| G | Browser extension: options page (URL base configurabile, salvataggio in `chrome.storage.sync`) | [#68](https://github.com/alkcxy/password-manager/issues/68) | — |
+| H | Browser extension: popup (credential list, fill trigger, login/logout) | [#67](https://github.com/alkcxy/password-manager/issues/67) | E, F, G |
+| I | Web app: banner/suggerimento installazione extension | [#69](https://github.com/alkcxy/password-manager/issues/69) | — |
+| J | `.dockerignore`: escludere `extension/` e `docs/` dall'immagine Docker | — | — |
 
 ---
 

--- a/test/controllers/api/sessions_controller_test.rb
+++ b/test/controllers/api/sessions_controller_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class Api::SessionsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(
+      name: "Alice",
+      email: "alice@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+  end
+
+  # POST /api/sessions
+
+  test "returns token when credentials are valid" do
+    post "/api/sessions", params: { email: @user.email, password: "password123" }, as: :json
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert json["token"].present?
+    assert json["expires_at"].present?
+    assert ApiToken.where(token: json["token"]).exists?
+  end
+
+  test "returns 401 when password is wrong" do
+    post "/api/sessions", params: { email: @user.email, password: "wrongpassword" }, as: :json
+    assert_response :unauthorized
+    json = JSON.parse(response.body)
+    assert json["error"].present?
+  end
+
+  test "returns 401 when email does not exist" do
+    post "/api/sessions", params: { email: "nobody@example.com", password: "password123" }, as: :json
+    assert_response :unauthorized
+    json = JSON.parse(response.body)
+    assert json["error"].present?
+  end
+
+  # DELETE /api/sessions/:token
+
+  test "destroys token and returns 204" do
+    api_token = ApiToken.generate_for(@user)
+    delete "/api/sessions/#{api_token.token}"
+    assert_response :no_content
+    assert_not ApiToken.where(token: api_token.token).exists?
+  end
+
+  test "returns 404 when token does not exist" do
+    delete "/api/sessions/nonexistenttoken000000000000000000000000000000000000000000000000"
+    assert_response :not_found
+    json = JSON.parse(response.body)
+    assert json["error"].present?
+  end
+end


### PR DESCRIPTION
## Summary

- Aggiunge `POST /api/sessions` per autenticazione: verifica email/password con `has_secure_password`, genera `ApiToken` e restituisce `{ token, expires_at }`
- Aggiunge `DELETE /api/sessions/:token` per logout: cancella il token da MongoDB
- Aggiunge gem `rack-attack` con throttle 5 req/min per IP su `POST /api/sessions`
- Route sotto namespace `api`

## Test plan

- [x] `POST /api/sessions` con credenziali valide → 201 + token
- [x] `POST /api/sessions` con password errata → 401
- [x] `POST /api/sessions` con email inesistente → 401
- [x] `DELETE /api/sessions/:token` con token valido → 204, token rimosso da DB
- [x] `DELETE /api/sessions/:token` con token inesistente → 404
- [x] Suite completa: 103 test, 0 failures

## Related

- Closes #63
- Part of ADR: `docs/adr/browser-extension.md` (step C)
- Depends on: #62 ✅
- Unblocks: #65 (content script), #66 (background service worker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)