### PR TITLE
feat: Api::CredentialsController — list by domain + show + create + rack-cors (story D, closes #64)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'propshaft'
 
 gem 'bootsnap', require: false
 gem 'rack-attack'
+gem 'rack-cors'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -194,6 +194,9 @@ GEM
     rack (3.2.6)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
+    rack-cors (3.0.0)
+      logger
+      rack (>= 3.0.14)
     rack-session (2.1.2)
       base64 (>= 0.1.0)
       rack (>= 3.0.0)
@@ -291,6 +294,7 @@ DEPENDENCIES
   propshaft
   puma (~> 6.0)
   rack-attack
+  rack-cors
   rails (~> 8.0)
   selenium-webdriver (~> 4.0)
   stimulus-rails

--- a/app/controllers/api/credentials_controller.rb
+++ b/app/controllers/api/credentials_controller.rb
@@ -29,6 +29,8 @@ module Api
       else
         render json: { errors: credential.errors.full_messages }, status: :unprocessable_entity
       end
+    rescue Mongo::Error::OperationFailure => e
+      render json: { errors: [e.message] }, status: :unprocessable_entity
     end
 
     private

--- a/app/controllers/api/credentials_controller.rb
+++ b/app/controllers/api/credentials_controller.rb
@@ -1,11 +1,15 @@
 module Api
   class CredentialsController < BaseController
     def index
-      credentials = if params[:domain].present?
+      credentials = @current_user.credentials
+
+      if params[:domain].present?
         escaped = Regexp.escape(params[:domain])
-        @current_user.credentials.where(url: /(?:\/\/|\.)#{escaped}(?:\/|:|$)/)
-      else
-        @current_user.credentials
+        credentials = credentials.where(url: /(?:\/\/|\.)#{escaped}(?:\/|:|$)/)
+      end
+
+      if params[:q].present?
+        credentials = credentials.where("$text" => { "$search" => params[:q] })
       end
 
       render json: credentials.map { |c| serialize_summary(c) }

--- a/app/controllers/api/credentials_controller.rb
+++ b/app/controllers/api/credentials_controller.rb
@@ -1,0 +1,45 @@
+module Api
+  class CredentialsController < BaseController
+    def index
+      credentials = if params[:domain].present?
+        escaped = Regexp.escape(params[:domain])
+        @current_user.credentials.where(url: /(?:\/\/|\.)#{escaped}(?:\/|:|$)/)
+      else
+        @current_user.credentials
+      end
+
+      render json: credentials.map { |c| serialize_summary(c) }
+    end
+
+    def show
+      credential = @current_user.credentials.find(params[:id])
+      render json: serialize_full(credential)
+    rescue Mongoid::Errors::DocumentNotFound
+      render json: { error: "Credential not found" }, status: :not_found
+    end
+
+    def create
+      credential = @current_user.credentials.build(credential_params)
+      if credential.save
+        render json: { id: credential.id.to_s, name: credential.name }, status: :created
+      else
+        render json: { errors: credential.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    private
+
+    def credential_params
+      params.permit(:name, :username, :password, :url, :note)
+    end
+
+    def serialize_summary(credential)
+      { id: credential.id.to_s, name: credential.name, username: credential.username, url: credential.url }
+    end
+
+    def serialize_full(credential)
+      { id: credential.id.to_s, name: credential.name, username: credential.username,
+        url: credential.url, password: credential.password, note: credential.note }
+    end
+  end
+end

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -10,10 +10,10 @@ class Credential
 
   belongs_to :user
 
-  index({ name: 1, user: 1 }, { unique: true })
+  index({ name: 1, user_id: 1 }, { unique: true })
   index({ user_id: 1, name: "text", url: "text" })
 
-  validates :user, uniqueness: { scope: :name, case_sensitive: false }
+  validates :name, uniqueness: { scope: :user_id, case_sensitive: false }
   validates_presence_of :name
   validates_presence_of :user
   validates_presence_of :username

--- a/app/models/credential.rb
+++ b/app/models/credential.rb
@@ -11,7 +11,7 @@ class Credential
   belongs_to :user
 
   index({ name: 1, user: 1 }, { unique: true })
-  index "$**": "text"
+  index({ user_id: 1, name: "text", url: "text" })
 
   validates :user, uniqueness: { scope: :name, case_sensitive: false }
   validates_presence_of :name

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,6 +1,6 @@
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins "chrome-extension://#{ENV.fetch('EXTENSION_ID', '*')}"
+    origins "chrome-extension://#{ENV.fetch('EXTENSION_ID')}"
 
     resource "/api/*",
              headers: :any,

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,0 +1,9 @@
+Rails.application.config.middleware.insert_before 0, Rack::Cors do
+  allow do
+    origins "chrome-extension://#{ENV.fetch('EXTENSION_ID', '*')}"
+
+    resource "/api/*",
+             headers: :any,
+             methods: [:get, :post, :delete, :options]
+  end
+end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -1,9 +1,8 @@
-Rails.application.config.middleware.insert_before 0, Rack::Cors do
-  allow do
-    origins "chrome-extension://#{ENV.fetch('EXTENSION_ID')}"
-
-    resource "/api/*",
-             headers: :any,
-             methods: [:get, :post, :delete, :options]
+if (extension_id = ENV["EXTENSION_ID"].presence)
+  Rails.application.config.middleware.insert_before 0, Rack::Cors do
+    allow do
+      origins "chrome-extension://#{extension_id}"
+      resource "/api/*", headers: :any, methods: [:get, :post, :delete, :options]
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 Rails.application.routes.draw do
   namespace :api do
     resources :sessions, only: [:create, :destroy], param: :token
-    # Story D: Api::CredentialsController (index, create)
+    resources :credentials, only: [:index, :show, :create]
   end
 
   get 'login', to: 'sessions#new'

--- a/docs/adr/browser-extension.md
+++ b/docs/adr/browser-extension.md
@@ -56,9 +56,10 @@ A new `ApiToken` Mongoid model will store tokens: `token` (opaque, SecureRandom 
 | `/api/sessions` | POST | `{ email, password }` | `{ token, expires_at }` |
 | `/api/sessions/:token` | DELETE | — | `204 No Content` |
 | `/api/credentials` | GET | `?domain=<host>` | `[{ id, name, username, url }]` |
+| `/api/credentials/:id` | GET | — | `{ id, name, username, url, password, note }` |
 | `/api/credentials` | POST | `{ name, username, password, url, note }` | `{ id, name }` |
 
-**Password is never returned by `GET /api/credentials`** — only metadata (name, username, url). This keeps credential exposure minimal.
+**`GET /api/credentials` (list) never returns the password** — only metadata. The password is exposed only via `GET /api/credentials/:id` (single credential), used by the extension popup to autofill the password field.
 
 All responses are JSON. All endpoints require `Authorization: Bearer <token>` except `POST /api/sessions`.
 
@@ -67,7 +68,7 @@ All responses are JSON. All endpoints require `Authorization: Bearer <token>` ex
 - New namespace: `app/controllers/api/`
 - `Api::BaseController`: reads and validates Bearer token, sets `current_user`
 - `Api::SessionsController`: create/destroy
-- `Api::CredentialsController`: index (filtered by domain via `url` field), create
+- `Api::CredentialsController`: index (filtered by domain via `url` field), show (returns password for autofill), create
 - CORS: add `rack-cors` gem, whitelist `chrome-extension://<extension-id>`
 - No changes to existing web controllers
 
@@ -115,7 +116,7 @@ Token expiry
 | No offline support | Extension needs the Rails app reachable on the network |
 | Extension ID changes on unpacked reload | CORS config must be updated each time; fixed once published on Chrome Web Store |
 | No Firefox support | MV3 divergence makes cross-browser support non-trivial; out of scope |
-| No password retrieval via extension | `GET /api/credentials` returns metadata only; a separate reveal endpoint can be added later |
+| No password retrieval via extension | `GET /api/credentials` returns metadata only; use `GET /api/credentials/:id` to retrieve the password for autofill |
 | Cross-origin iframes | Login forms embedded from a different domain (Auth0, Okta, Stripe) are inaccessible to the content script — hard browser limit |
 | Shadow DOM | Form fields inside Shadow DOM components may not be reachable via standard `querySelector` |
 | Non-standard SPA event handling | Some React/Vue apps require specific synthetic events to detect programmatically injected values; requires per-site testing |

--- a/docs/adr/browser-extension.md
+++ b/docs/adr/browser-extension.md
@@ -56,7 +56,26 @@ Add the Base64 output to `manifest.json`:
 
 The resulting ID (visible in `chrome://extensions` after loading unpacked) is set once in the Rails environment as `EXTENSION_ID` and never changes. The private key (`key.pem`) must be kept secret and excluded from version control.
 
-**HTTP in development**: Chrome treats `localhost` as a secure context — the extension can call `http://localhost:3000` without HTTPS. No special setup needed for local testing.
+**HTTP in development (localhost only)**: Chrome treats `localhost` as a secure context — the extension can call `http://localhost:3000` without HTTPS. No special setup needed when the browser and the Rails server are on the same machine.
+
+**HTTP in development (LAN, server on a different machine)**: `http://192.168.x.x` is not a secure context — Chrome blocks requests from the extension to a plain HTTP LAN address. Use `mkcert` to issue a locally-trusted certificate for the LAN IP:
+
+```bash
+# install mkcert and its root CA (once per machine)
+mkcert -install
+
+# issue a cert for the LAN IP (replace with your actual IP)
+mkcert 192.168.1.100
+# produces: 192.168.1.100.pem  192.168.1.100-key.pem
+```
+
+Then start Puma with TLS:
+
+```bash
+bin/rails server -b "ssl://0.0.0.0:3000?key=192.168.1.100-key.pem&cert=192.168.1.100.pem"
+```
+
+The extension Options page should be set to `https://192.168.1.100:3000`. The mkcert root CA must be installed on every machine whose browser will connect (run `mkcert -install` there too).
 
 ### Configurable base URL
 

--- a/docs/adr/browser-extension.md
+++ b/docs/adr/browser-extension.md
@@ -31,11 +31,32 @@ Plain JavaScript + ES modules — no Node.js build pipeline. Consistent with the
 
 ### Distribution
 
-Published on the Chrome Web Store ($5 one-time developer fee). This gives the extension a stable, permanent ID — which means the CORS whitelist in Rails never needs to change after the initial setup.
+Published on the Chrome Web Store ($5 one-time developer fee).
 
 For development, load as unpacked extension:
 - Vivaldi: `vivaldi://extensions`
 - Chrome: `chrome://extensions`
+
+### Stable extension ID (development + production)
+
+The extension ID is derived deterministically from a keypair baked into `manifest.json`. This means the ID is stable across reloads and reinstalls — no need to update the CORS config each time, and no dependency on Chrome Web Store publication for a fixed ID.
+
+Generate the keypair once:
+
+```bash
+openssl genrsa 2048 | openssl pkcs8 -topk8 -nocrypt -out extension/key.pem
+openssl rsa -in extension/key.pem -pubout -outform DER | base64 -w0
+```
+
+Add the Base64 output to `manifest.json`:
+
+```json
+"key": "<base64-encoded-public-key>"
+```
+
+The resulting ID (visible in `chrome://extensions` after loading unpacked) is set once in the Rails environment as `EXTENSION_ID` and never changes. The private key (`key.pem`) must be kept secret and excluded from version control.
+
+**HTTP in development**: Chrome treats `localhost` as a secure context — the extension can call `http://localhost:3000` without HTTPS. No special setup needed for local testing.
 
 ### Configurable base URL
 
@@ -102,7 +123,7 @@ Token expiry
 ## Security considerations
 
 - **HTTPS assumed.** The app is deployed on a public domain under HTTPS — no self-signed cert setup needed.
-- **CORS:** whitelist only `chrome-extension://<extension-id>`. With Chrome Web Store publication the ID is permanent, so this is a one-time configuration.
+- **CORS:** whitelist only `chrome-extension://<extension-id>`. The ID is stable because it is derived from the keypair in `manifest.json` — set `EXTENSION_ID` env var once, never touch it again.
 - **Rate-limit** `POST /api/sessions` to prevent brute-force (e.g. `rack-attack`, 5 req/min per IP).
 - **Token rotation:** not implemented in v1; acceptable for personal use.
 - **No auto-submit:** the content script fills fields only — the user always clicks Submit themselves.
@@ -114,7 +135,6 @@ Token expiry
 | Limitation | Notes |
 |---|---|
 | No offline support | Extension needs the Rails app reachable on the network |
-| Extension ID changes on unpacked reload | CORS config must be updated each time; fixed once published on Chrome Web Store |
 | No Firefox support | MV3 divergence makes cross-browser support non-trivial; out of scope |
 | No password retrieval via extension | `GET /api/credentials` returns metadata only; use `GET /api/credentials/:id` to retrieve the password for autofill |
 | Cross-origin iframes | Login forms embedded from a different domain (Auth0, Okta, Stripe) are inaccessible to the content script — hard browser limit |

--- a/test/controllers/api/credentials_controller_test.rb
+++ b/test/controllers/api/credentials_controller_test.rb
@@ -170,6 +170,18 @@ class Api::CredentialsControllerTest < ActionDispatch::IntegrationTest
     assert json["errors"].present?
   end
 
+  test "create returns 422 with JSON when credential name already exists for same user" do
+    assert_no_difference -> { Credential.count } do
+      post "/api/credentials",
+           params: { name: @github_cred.name, username: "alice", password: "pass", url: "https://github.com" },
+           headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    end
+    assert_response :unprocessable_entity
+    assert_equal "application/json; charset=utf-8", response.content_type
+    json = JSON.parse(response.body)
+    assert json["errors"].present?
+  end
+
   test "create does not write to DB when params are invalid" do
     assert_no_difference -> { Credential.count } do
       post "/api/credentials",

--- a/test/controllers/api/credentials_controller_test.rb
+++ b/test/controllers/api/credentials_controller_test.rb
@@ -1,0 +1,177 @@
+require "test_helper"
+
+class Api::CredentialsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = User.create!(
+      name: "Alice",
+      email: "alice@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    @other_user = User.create!(
+      name: "Bob",
+      email: "bob@example.com",
+      password: "password123",
+      password_confirmation: "password123"
+    )
+    @token = ApiToken.generate_for(@user)
+    @other_token = ApiToken.generate_for(@other_user)
+
+    @github_cred = Credential.create!(
+      name: "GitHub",
+      username: "alice",
+      password: "secret123",
+      url: "https://github.com/login",
+      user: @user
+    )
+    @gitlab_cred = Credential.create!(
+      name: "GitLab",
+      username: "alice",
+      password: "secret456",
+      url: "https://gitlab.com/login",
+      user: @user
+    )
+    @other_cred = Credential.create!(
+      name: "GitHub Bob",
+      username: "bob",
+      password: "bobsecret",
+      url: "https://github.com/login",
+      user: @other_user
+    )
+  end
+
+  # GET /api/credentials?domain=
+
+  test "index returns 401 without token" do
+    get "/api/credentials", params: { domain: "github.com" }, as: :json
+    assert_response :unauthorized
+    assert_equal "application/json; charset=utf-8", response.content_type
+  end
+
+  test "index returns credentials matching domain" do
+    get "/api/credentials", params: { domain: "github.com" },
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_equal 1, json.length
+    assert_equal @github_cred.id.to_s, json.first["id"]
+    assert_equal "GitHub", json.first["name"]
+    assert_equal "alice", json.first["username"]
+    assert json.first["url"].present?
+    assert_nil json.first["password"]
+  end
+
+  test "index returns empty array when no credentials match domain" do
+    get "/api/credentials", params: { domain: "twitter.com" },
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    assert_equal [], JSON.parse(response.body)
+  end
+
+  test "index does not return other users credentials" do
+    get "/api/credentials", params: { domain: "github.com" },
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    json = JSON.parse(response.body)
+    ids = json.map { |c| c["id"] }
+    assert_not_includes ids, @other_cred.id.to_s
+  end
+
+  test "index does not match superdomain (mygithub.com must not match github.com)" do
+    Credential.create!(
+      name: "MyGitHub",
+      username: "alice",
+      password: "fake",
+      url: "https://mygithub.com/login",
+      user: @user
+    )
+    get "/api/credentials", params: { domain: "github.com" },
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert json.none? { |c| c["name"] == "MyGitHub" }
+  end
+
+  test "index without domain param returns all user credentials" do
+    get "/api/credentials",
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_equal 2, json.length
+    assert json.none? { |c| c["password"].present? }
+  end
+
+  # GET /api/credentials/:id
+
+  test "show returns 401 without token" do
+    get "/api/credentials/#{@github_cred.id}", as: :json
+    assert_response :unauthorized
+    assert_equal "application/json; charset=utf-8", response.content_type
+  end
+
+  test "show returns credential with password for owner" do
+    get "/api/credentials/#{@github_cred.id}",
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert_equal @github_cred.id.to_s, json["id"]
+    assert_equal "GitHub", json["name"]
+    assert_equal "alice", json["username"]
+    assert_equal "secret123", json["password"]
+    assert json["url"].present?
+  end
+
+  test "show returns 404 when credential belongs to another user" do
+    get "/api/credentials/#{@other_cred.id}",
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :not_found
+    assert_equal "application/json; charset=utf-8", response.content_type
+  end
+
+  test "show returns 404 for nonexistent id" do
+    get "/api/credentials/000000000000000000000000",
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :not_found
+  end
+
+  # POST /api/credentials
+
+  test "create returns 401 without token" do
+    post "/api/credentials",
+         params: { name: "Test", username: "user", password: "pass", url: "https://test.com" },
+         as: :json
+    assert_response :unauthorized
+    assert_equal "application/json; charset=utf-8", response.content_type
+  end
+
+  test "create returns 201 with valid params" do
+    assert_difference -> { Credential.where(user: @user).count }, 1 do
+      post "/api/credentials",
+           params: { name: "Twitter", username: "alice", password: "twitterpass", url: "https://twitter.com" },
+           headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    end
+    assert_response :created
+    json = JSON.parse(response.body)
+    assert json["id"].present?
+    assert_equal "Twitter", json["name"]
+    assert_nil json["password"]
+  end
+
+  test "create returns 422 when required params are missing" do
+    post "/api/credentials",
+         params: { name: "NoUrl", username: "alice", password: "pass" },
+         headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :unprocessable_entity
+    assert_equal "application/json; charset=utf-8", response.content_type
+    json = JSON.parse(response.body)
+    assert json["errors"].present?
+  end
+
+  test "create does not write to DB when params are invalid" do
+    assert_no_difference -> { Credential.count } do
+      post "/api/credentials",
+           params: { username: "alice", password: "pass", url: "https://test.com" },
+           headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    end
+  end
+end

--- a/test/controllers/api/credentials_controller_test.rb
+++ b/test/controllers/api/credentials_controller_test.rb
@@ -2,6 +2,9 @@ require "test_helper"
 
 class Api::CredentialsControllerTest < ActionDispatch::IntegrationTest
   setup do
+    Credential.remove_indexes
+    Credential.create_indexes
+
     @user = User.create!(
       name: "Alice",
       email: "alice@example.com",
@@ -173,5 +176,46 @@ class Api::CredentialsControllerTest < ActionDispatch::IntegrationTest
            params: { username: "alice", password: "pass", url: "https://test.com" },
            headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
     end
+  end
+
+  # GET /api/credentials?q=
+
+  test "index with q returns credentials matching name" do
+    get "/api/credentials", params: { q: "GitHub" },
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert json.any? { |c| c["id"] == @github_cred.id.to_s }
+    assert json.none? { |c| c["id"] == @gitlab_cred.id.to_s }
+  end
+
+  test "index with q returns empty array when no name matches" do
+    get "/api/credentials", params: { q: "nonexistent" },
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    assert_equal [], JSON.parse(response.body)
+  end
+
+  test "index with q does not return other users credentials" do
+    get "/api/credentials", params: { q: "GitHub" },
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert json.none? { |c| c["id"] == @other_cred.id.to_s }
+  end
+
+  test "index with q and domain applies both filters" do
+    get "/api/credentials", params: { q: "GitHub", domain: "github.com" },
+        headers: { "Authorization" => "Bearer #{@token.token}" }, as: :json
+    assert_response :ok
+    json = JSON.parse(response.body)
+    assert json.any? { |c| c["id"] == @github_cred.id.to_s }
+    assert json.none? { |c| c["id"] == @gitlab_cred.id.to_s }
+  end
+
+  test "index with q without token returns 401" do
+    get "/api/credentials", params: { q: "GitHub" }, as: :json
+    assert_response :unauthorized
+    assert_equal "application/json; charset=utf-8", response.content_type
   end
 end


### PR DESCRIPTION
## Summary

- GET /api/credentials?domain= — lista senza password, regex anti-falsi-positivi
- GET /api/credentials?q= — ricerca full-text su nome e URL, combinabile con domain (AND)
- GET /api/credentials/:id — singola credenziale con password per autofill
- POST /api/credentials — crea credenziale, cifratura delegata a PasswordType
- rack-cors condizionale: senza EXTENSION_ID il middleware non viene caricato
- Indice MongoDB aggiornato: { user_id, name text, url text }
- ADR aggiornato: keypair per ID stabile, HTTP localhost dev, mkcert LAN

## Azione richiesta in produzione

Dopo il deploy eseguire:

    bin/rails db:mongoid:create_indexes

Sostituisce il vecchio wildcard text index con il nuovo indice scoped per user_id.

## Workaround

EXTENSION_ID da impostare in story E (#65) quando viene creato manifest.json. Istruzioni in docs/adr/browser-extension.md.

## Test

122 runs, 313 assertions, 0 failures. Test manuale su tutti gli endpoint, isolamento cross-user confermato.

Closes #64. Blocks #65, #66.