### PR TITLE
feat(extension): options page (#68)

### DIFF
--- a/docs/adr/browser-extension.md
+++ b/docs/adr/browser-extension.md
@@ -171,14 +171,26 @@ Le seguenti issue vanno lavorate in ordine — ogni step è prerequisito del suc
 |---|---|---|---|
 | A | ~~HTTPS/TLS setup~~ _(non necessario: dominio pubblico con HTTPS)_ | [#61](https://github.com/alkcxy/password-manager/issues/61) | — |
 | B | ~~Rails API layer: `ApiToken` model + `Api::BaseController` + token auth~~ | [#62](https://github.com/alkcxy/password-manager/issues/62) | — |
-| C | Rails API: `Api::SessionsController` (login/logout) + `rack-attack` | [#63](https://github.com/alkcxy/password-manager/issues/63) | B |
-| D | Rails API: `Api::CredentialsController` (index per domain, create) + `rack-cors` | [#64](https://github.com/alkcxy/password-manager/issues/64) | B |
-| E | Browser extension: content script (capture + save prompt) | [#65](https://github.com/alkcxy/password-manager/issues/65) | C, D |
-| F | Browser extension: background service worker (token management, API calls, URL configurabile) | [#66](https://github.com/alkcxy/password-manager/issues/66) | C, D |
+| C | ~~Rails API: `Api::SessionsController` (login/logout) + `rack-attack`~~ | [#63](https://github.com/alkcxy/password-manager/issues/63) | B |
+| D | ~~Rails API: `Api::CredentialsController` (index per domain, create) + `rack-cors`~~ | [#64](https://github.com/alkcxy/password-manager/issues/64) | B |
+| E | ~~Browser extension: content script (capture + save prompt)~~ | [#65](https://github.com/alkcxy/password-manager/issues/65) | C, D |
+| F | Browser extension: background service worker (token management, API calls, URL configurabile) | [#66](https://github.com/alkcxy/password-manager/issues/66) | C, D, G |
 | G | Browser extension: options page (URL base configurabile, salvataggio in `chrome.storage.sync`) | [#68](https://github.com/alkcxy/password-manager/issues/68) | — |
 | H | Browser extension: popup (credential list, fill trigger, login/logout) | [#67](https://github.com/alkcxy/password-manager/issues/67) | E, F, G |
 | I | Web app: banner/suggerimento installazione extension | [#69](https://github.com/alkcxy/password-manager/issues/69) | — |
-| J | `.dockerignore`: escludere `extension/` e `docs/` dall'immagine Docker | — | — |
+| J | ~~`.dockerignore`: escludere `extension/` e `docs/` dall'immagine Docker~~ | — | — |
+
+---
+
+## Implementation notes (storia E)
+
+Scoperte durante l'implementazione del content script:
+
+- **`chrome.storage.session` non disponibile nei content script** (almeno su Vivaldi): si usa `chrome.storage.local` con cleanup immediato dopo l'uso.
+- **`MutationObserver` su `document.documentElement`**, non su `document.body`: Turbo Drive sostituisce `document.body` ad ogni navigazione, rendendo inutile un observer attaccato al vecchio body.
+- **SPA senza `<form>`** (es. Authelia/MUI): il submit avviene via `fetch` senza evento `submit`. Il content script trova il bottone di submit per posizione nel DOM (`compareDocumentPosition`) invece che per `type="submit"`.
+- **Login in due fasi** (es. Microsoft, Google): username e password sono su pagine separate. Il content script salva il username in `pendingUsername` (memoria + `chrome.storage.local`) durante la fase 1 e lo consuma durante la fase 2.
+- **Rilevamento successo login rimosso**: l'estensione non può sapere se il login è andato a buon fine senza conoscere la logica del sito. Il banner compare sempre dopo ogni navigazione post-submit; l'utente decide se salvare.
 
 ---
 

--- a/docs/piano-storia-g.md
+++ b/docs/piano-storia-g.md
@@ -1,0 +1,65 @@
+# Piano — Storia G: Options Page (#68)
+
+**Branch:** `feature/options-page-story-g`  
+**Issue:** https://github.com/alkcxy/password-manager/issues/68  
+**Dipende da:** nessuna  
+**Blocca:** #66 (background service worker), #67 (popup)
+
+---
+
+## Cosa dice l'issue vs ADR
+
+L'ADR dice solo "options page, URL base in `chrome.storage.sync`". L'issue aggiunge:
+- Validare che sia **HTTPS** (non solo URL valida)
+- Feedback visivo al salvataggio
+- Il background service worker leggerà da `chrome.storage.sync` ad ogni chiamata API
+
+---
+
+## File da creare/modificare
+
+| File | Azione |
+|---|---|
+| `extension/options.html` | creare |
+| `extension/options.js` | creare |
+| `extension/manifest.json` | aggiungere `options_ui` |
+
+---
+
+## Prerequisiti verificati
+
+| Prerequisito | Stato |
+|---|---|
+| Permesso `storage` nel manifest | ✅ già presente |
+| `chrome.storage.sync` (API) | ✅ disponibile |
+| `options_ui` nel manifest | da aggiungere |
+
+---
+
+## Comportamento atteso
+
+- Form con un campo "URL della tua istanza" (es. `https://pm.example.com`)
+- Validazione: URL valida **e** schema HTTPS
+- Salvataggio in `chrome.storage.sync` alla conferma
+- Feedback visivo al salvataggio (es. messaggio "Salvato")
+- Al riapertura della options page, il campo mostra il valore già salvato
+
+---
+
+## Test plan manuale
+
+1. Aprire la options page da `chrome://extensions` → "Dettagli" → "Opzioni"
+2. Inserire URL HTTPS valida (es. `https://pm.example.com`) → salvare → riaprire → URL persiste
+3. Inserire URL non HTTPS (es. `http://pm.example.com`) → deve mostrare errore
+4. Inserire URL malformata (es. `not-a-url`) → deve mostrare errore
+5. Salvare senza aver inserito nulla → errore o campo vuoto non salvato
+6. Verificare valore in DevTools → Application → Storage → Extension Storage → Sync
+
+---
+
+## Note architetturali
+
+- `chrome.storage.sync` sincronizza la preferenza tra dispositivi dello stesso account Chrome/Google
+- La chiave da usare in storage: `baseUrl`
+- JS puro, nessun build pipeline (coerente con l'ADR e il resto dell'extension)
+- Dopo storia G, la storia F (background service worker) leggerà `baseUrl` da `chrome.storage.sync` ad ogni chiamata API

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,6 +5,10 @@
   "description": "Save and autofill credentials from your self-hosted password manager.",
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvlF4eW0Da4gp/NbbPjCvJCpO9s9T75TI3XbOLNonBioT71/MbiKKTxVSmctMZG91ZTkzVPWlOIYqjjcxmzkDJwnC45UiB99X1swxWEXkaOHm8RZSmaoZLSqa4897/gMY0NnAwnmCszrgUzECB7xbf70Ebylp6TA2fIf7g/9q+AQ2VdqYcrILNfjPHNjDA/1Z1VieV8ljzMejMsItZDSI0vZY1Cej1EE33IinpVDdH4Gb3VbRNMPTG0rQTJqQNd3Px8CLG5xGF5RvPeC5VmoXILCRCei6PGcAGpxzLzWCAGHKhvU6vnkxZNNQiOv8oAsHZpnbC/9bj0Fne9KNR0Q9TwIDAQAB",
   "permissions": ["storage"],
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
+  },
   "host_permissions": ["<all_urls>"],
   "content_scripts": [
     {

--- a/extension/options.html
+++ b/extension/options.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="it">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Password Manager — Opzioni</title>
+  <style>
+    body {
+      font-family: sans-serif;
+      padding: 24px;
+      max-width: 480px;
+    }
+    h1 { font-size: 1.2rem; margin-bottom: 20px; }
+    label { display: block; margin-bottom: 6px; font-weight: bold; }
+    input[type="url"] {
+      width: 100%;
+      padding: 8px;
+      font-size: 1rem;
+      box-sizing: border-box;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+    }
+    input[type="url"].error { border-color: #c00; }
+    #error-msg {
+      color: #c00;
+      font-size: 0.875rem;
+      margin-top: 6px;
+      min-height: 1.2em;
+    }
+    button {
+      margin-top: 12px;
+      padding: 8px 20px;
+      font-size: 1rem;
+      cursor: pointer;
+    }
+    #status {
+      margin-top: 10px;
+      color: green;
+      font-size: 0.875rem;
+      min-height: 1.2em;
+    }
+  </style>
+</head>
+<body>
+  <h1>Impostazioni Password Manager</h1>
+  <label for="base-url">URL della tua istanza</label>
+  <input type="url" id="base-url" placeholder="https://pm.example.com">
+  <div id="error-msg"></div>
+  <button id="save-btn">Salva</button>
+  <div id="status"></div>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,8 +1,10 @@
-function validateUrl(input, value) {
+const VALID_URL = /^https:\/\/(localhost|\d{1,3}(\.\d{1,3}){3}|[a-zA-Z0-9][a-zA-Z0-9-]*(\.[a-zA-Z0-9][a-zA-Z0-9-]*)+)(:\d{1,5})?(\/[^\s]*)?$/;
+
+function validateUrl(value) {
   if (!value) return "Inserisci un URL.";
-  if (!input.validity.valid) return "URL non valida.";
-  if (!value.startsWith("https://")) return "L'URL deve usare HTTPS.";
-  return null;
+  if (VALID_URL.test(value)) return null;
+  if (/^http:\/\//i.test(value)) return "L'URL deve usare HTTPS.";
+  return "URL non valida.";
 }
 
 const input = document.getElementById("base-url");
@@ -16,8 +18,7 @@ chrome.storage.sync.get("baseUrl", ({ baseUrl }) => {
 
 saveBtn.addEventListener("click", () => {
   const value = input.value.trim();
-  input.value = value;
-  const error = validateUrl(input, value);
+  const error = validateUrl(value);
 
   errorMsg.textContent = error ?? "";
   input.classList.toggle("error", error !== null);

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,0 +1,36 @@
+function validateUrl(value) {
+  if (!value) return "Inserisci un URL.";
+  let parsed;
+  try {
+    parsed = new URL(value);
+  } catch {
+    return "URL non valida.";
+  }
+  if (parsed.protocol !== "https:") return "L'URL deve usare HTTPS.";
+  return null;
+}
+
+const input = document.getElementById("base-url");
+const errorMsg = document.getElementById("error-msg");
+const status = document.getElementById("status");
+const saveBtn = document.getElementById("save-btn");
+
+chrome.storage.sync.get("baseUrl", ({ baseUrl }) => {
+  if (baseUrl) input.value = baseUrl;
+});
+
+saveBtn.addEventListener("click", () => {
+  const value = input.value.trim();
+  const error = validateUrl(value);
+
+  errorMsg.textContent = error ?? "";
+  input.classList.toggle("error", error !== null);
+  status.textContent = "";
+
+  if (error) return;
+
+  chrome.storage.sync.set({ baseUrl: value }, () => {
+    status.textContent = "Salvato.";
+    setTimeout(() => { status.textContent = ""; }, 3000);
+  });
+});

--- a/extension/options.js
+++ b/extension/options.js
@@ -6,6 +6,7 @@ function validateUrl(value) {
   } catch {
     return "URL non valida.";
   }
+  if (!parsed.hostname) return "URL non valida.";
   if (parsed.protocol !== "https:") return "L'URL deve usare HTTPS.";
   return null;
 }

--- a/extension/options.js
+++ b/extension/options.js
@@ -6,8 +6,10 @@ function validateUrl(value) {
   } catch {
     return "URL non valida.";
   }
-  if (!parsed.hostname) return "URL non valida.";
   if (parsed.protocol !== "https:") return "L'URL deve usare HTTPS.";
+  // Catches "https:/foo" where Chrome parses hostname correctly but structure is wrong
+  if (!value.startsWith("https://")) return "URL non valida.";
+  if (!parsed.hostname) return "URL non valida.";
   return null;
 }
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,10 +1,16 @@
-const VALID_URL = /^https:\/\/(localhost|\d{1,3}(\.\d{1,3}){3}|[a-zA-Z0-9][a-zA-Z0-9-]*(\.[a-zA-Z0-9][a-zA-Z0-9-]*)+)(:\d{1,5})?(\/[^\s]*)?$/;
+const TIMEOUT_MS = 5000;
 
-function validateUrl(value) {
-  if (!value) return "Inserisci un URL.";
-  if (VALID_URL.test(value)) return null;
-  if (/^http:\/\//i.test(value)) return "L'URL deve usare HTTPS.";
-  return "URL non valida.";
+async function reachable(url) {
+  const controller = new AbortController();
+  const id = setTimeout(() => controller.abort(), TIMEOUT_MS);
+  try {
+    const res = await fetch(url, { signal: controller.signal });
+    return res.ok ? null : `Il sito ha risposto con errore (${res.status}).`;
+  } catch {
+    return "Impossibile raggiungere il sito.";
+  } finally {
+    clearTimeout(id);
+  }
 }
 
 const input = document.getElementById("base-url");
@@ -16,13 +22,33 @@ chrome.storage.sync.get("baseUrl", ({ baseUrl }) => {
   if (baseUrl) input.value = baseUrl;
 });
 
-saveBtn.addEventListener("click", () => {
+saveBtn.addEventListener("click", async () => {
   const value = input.value.trim();
-  const error = validateUrl(value);
 
+  errorMsg.textContent = "";
+  input.classList.remove("error");
+  status.textContent = "";
+
+  if (!value) {
+    errorMsg.textContent = "Inserisci un URL.";
+    input.classList.add("error");
+    return;
+  }
+  if (!value.startsWith("https://")) {
+    errorMsg.textContent = "L'URL deve usare HTTPS.";
+    input.classList.add("error");
+    return;
+  }
+
+  saveBtn.disabled = true;
+  status.textContent = "Verifica in corso…";
+
+  const error = await reachable(value);
+
+  saveBtn.disabled = false;
+  status.textContent = "";
   errorMsg.textContent = error ?? "";
   input.classList.toggle("error", error !== null);
-  status.textContent = "";
 
   if (error) return;
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -7,9 +7,8 @@ function validateUrl(value) {
     return "URL non valida.";
   }
   if (parsed.protocol !== "https:") return "L'URL deve usare HTTPS.";
-  // Catches "https:/foo" where Chrome parses hostname correctly but structure is wrong
   if (!value.startsWith("https://")) return "URL non valida.";
-  if (!parsed.hostname) return "URL non valida.";
+  if (!parsed.hostname || parsed.hostname.startsWith(".") || parsed.hostname.includes("..")) return "URL non valida.";
   return null;
 }
 

--- a/extension/options.js
+++ b/extension/options.js
@@ -1,14 +1,7 @@
-function validateUrl(value) {
+function validateUrl(input, value) {
   if (!value) return "Inserisci un URL.";
-  let parsed;
-  try {
-    parsed = new URL(value);
-  } catch {
-    return "URL non valida.";
-  }
-  if (parsed.protocol !== "https:") return "L'URL deve usare HTTPS.";
-  if (!value.startsWith("https://")) return "URL non valida.";
-  if (!parsed.hostname || parsed.hostname.startsWith(".") || parsed.hostname.includes("..")) return "URL non valida.";
+  if (!input.validity.valid) return "URL non valida.";
+  if (!value.startsWith("https://")) return "L'URL deve usare HTTPS.";
   return null;
 }
 
@@ -23,7 +16,8 @@ chrome.storage.sync.get("baseUrl", ({ baseUrl }) => {
 
 saveBtn.addEventListener("click", () => {
   const value = input.value.trim();
-  const error = validateUrl(value);
+  input.value = value;
+  const error = validateUrl(input, value);
 
   errorMsg.textContent = error ?? "";
   input.classList.toggle("error", error !== null);

--- a/extension/options.js
+++ b/extension/options.js
@@ -34,6 +34,6 @@ saveBtn.addEventListener("click", () => {
 
   chrome.storage.sync.set({ baseUrl: value }, () => {
     status.textContent = "Salvato.";
-    setTimeout(() => { status.textContent = ""; }, 3000);
+    setTimeout(() => window.close(), 800);
   });
 });


### PR DESCRIPTION
## Summary

- Aggiunge `extension/options.html` e `extension/options.js` per configurare l'URL base dell'istanza self-hosted
- Validazione: URL valida **e** schema HTTPS obbligatorio
- Al riapertura della options page il campo mostra il valore già salvato (`chrome.storage.sync`)
- Aggiunge `options_ui` al `manifest.json`

## Test plan manuale

- [x] Aprire `chrome://extensions` → "Dettagli" → "Opzioni" → pannello si apre
- [x] Inserire `https://pm.example.com` → Salva → riapri → URL persiste
- [x] Inserire `http://pm.example.com` → errore "L'URL deve usare HTTPS."
- [x] Inserire `not-a-url` → errore "URL non valida."
- [x] Salvare con campo vuoto → errore "Inserisci un URL."
- [x] Verificare in DevTools → Application → Extension Storage → Sync → chiave `baseUrl`

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)