### PR TITLE
feat(extension): nascondi lista credenziali se pagina senza campi password

### DIFF
--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -244,6 +244,9 @@
       fillCredential(message.payload);
       sendResponse({ status: 'ok' });
     }
+    if (message.type === 'HAS_PASSWORD_FIELD') {
+      sendResponse({ hasPasswordField: !!document.querySelector('input[type="password"]') });
+    }
     return true;
   });
 

--- a/extension/popup.js
+++ b/extension/popup.js
@@ -61,6 +61,20 @@ async function showCredentials() {
   const { loggedEmail } = await chrome.storage.local.get('loggedEmail');
   loggedAs.textContent = loggedEmail ? `Loggato come ${loggedEmail}` : '';
 
+  let hasPasswordField = false;
+  if (activeTabId != null) {
+    try {
+      const res = await chrome.tabs.sendMessage(activeTabId, { type: 'HAS_PASSWORD_FIELD' });
+      hasPasswordField = res?.hasPasswordField === true;
+    } catch (_) {}
+  }
+  if (!hasPasswordField) {
+    loadingMsg.hidden = true;
+    emptyMsg.textContent = 'Nessun campo password rilevato in questa pagina.';
+    emptyMsg.hidden = false;
+    return;
+  }
+
   if (!activeDomain) {
     loadingMsg.hidden = true;
     emptyMsg.textContent = 'Impossibile determinare il dominio della pagina.';


### PR DESCRIPTION
## Summary
- Il popup interroga il content script con un nuovo messaggio `HAS_PASSWORD_FIELD` prima di chiamare l'API credenziali
- Se la pagina non ha `input[type="password"]`, mostra "Nessun campo password rilevato in questa pagina" e salta la chiamata API
- Tab senza content script (`chrome://`, PDF, `chrome-extension://`) vengono trattati silenziosamente come "nessun campo password"

## Test plan manuale
1. **Pagina con campo password** (es. `/users/sign_in`): popup mostra lista credenziali con pulsanti "Compila"
2. **Pagina senza campi password** (es. dashboard, `google.com`): popup mostra "Nessun campo password rilevato in questa pagina" — nessuna chiamata HTTP all'API (verificare Network tab)
3. **Tab speciale** (`chrome://settings`): `sendMessage` fallisce silenziosamente → messaggio informativo
4. **Utente non autenticato** su pagina senza campi password: popup mostra schermata di login (il controllo avviene solo dentro `showCredentials`)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)