### PR TITLE
fix(extension): non mostrare banner se credenziale già presente per il dominio

### DIFF
--- a/extension/TEST_PLAN_banner_no_duplicate.md
+++ b/extension/TEST_PLAN_banner_no_duplicate.md
@@ -31,37 +31,17 @@ Ogni test va eseguito almeno una volta sull'ambiente reale prima di considerare 
 
 ---
 
-## T03 — Token scaduto: banner di login appare
+## T03 — Token scaduto: banner informativo appare
 
 **Precondizione:** token scaduto (`expiresAt` nel passato) o assente.
 
 **Azione:** compilare e inviare un form di login su qualsiasi sito.
 
-**Atteso:** appare il banner "Accedi all'estensione per salvare le credenziali su questo sito." con i pulsanti "Accedi" e "Ignora".
+**Atteso:** appare il banner "Accedi all'estensione per salvare le credenziali su questo sito." senza pulsanti. Il banner non riappare sulle pagine successive (credenziale pendente cancellata).
 
 ---
 
-## T03a — Click "Accedi" su banner di login: popup si apre
-
-**Precondizione:** banner di login visibile (da T03).
-
-**Azione:** cliccare "Accedi".
-
-**Atteso:** il banner scompare; il popup dell'estensione si apre.
-
----
-
-## T03b — Click "Ignora" su banner di login: credenziale pendente cancellata
-
-**Precondizione:** banner di login visibile (da T03).
-
-**Azione:** cliccare "Ignora".
-
-**Atteso:** il banner scompare; navigando di nuovo sullo stesso sito il banner non riappare (credenziale pendente cancellata).
-
----
-
-## T04 — Estensione non configurata: banner di login appare
+## T04 — Estensione non configurata: banner informativo appare
 
 **Precondizione:** `baseUrl` non configurata (`await chrome.storage.sync.remove('baseUrl')`).
 
@@ -78,13 +58,3 @@ Ogni test va eseguito almeno una volta sull'ambiente reale prima di considerare 
 **Azione:** tornare sulla pagina di login e ripetere il login.
 
 **Atteso:** nessun banner appare.
-
----
-
-## T06 — Dopo login via banner di autenticazione: banner salvataggio riappare
-
-**Precondizione:** T03 completato (banner di login mostrato, credenziale pendente ancora in storage); nessuna credenziale per il dominio.
-
-**Azione:** cliccare "Accedi" → effettuare il login nel popup → navigare sulla pagina originale.
-
-**Atteso:** appare il banner di salvataggio (la credenziale pendente è ancora in storage e ora l'utente è autenticato).

--- a/extension/TEST_PLAN_banner_no_duplicate.md
+++ b/extension/TEST_PLAN_banner_no_duplicate.md
@@ -1,0 +1,60 @@
+# Test Plan — Banner salvataggio: skip se credenziale già presente (Issue #85)
+
+Questo documento va committato nello stesso commit del codice produttivo.
+Ogni test va eseguito almeno una volta sull'ambiente reale prima di considerare la storia "done".
+
+## Setup comune
+
+1. Server Rails raggiungibile (es. `http://localhost:3000`).
+2. Estensione caricata e configurata con `baseUrl` + utente autenticato.
+3. Ricaricare l'estensione su `chrome://extensions` dopo ogni modifica al codice.
+
+---
+
+## T01 — Credenziale già presente: banner NON appare
+
+**Precondizione:** esiste almeno una credenziale per il dominio del sito di test (es. `localhost`).
+
+**Azione:** compilare e inviare un form di login su quel sito.
+
+**Atteso:** dopo il redirect post-login, il banner "Salva nel password manager?" **non appare**.
+
+---
+
+## T02 — Nessuna credenziale per il dominio: banner appare
+
+**Precondizione:** nessuna credenziale salvata per il dominio del sito di test.
+
+**Azione:** compilare e inviare un form di login.
+
+**Atteso:** dopo il redirect post-login, il banner **appare** con il messaggio "Salva `<username>` nel password manager?".
+
+---
+
+## T03 — Fail open: token scaduto → banner appare
+
+**Precondizione:** token scaduto (`expiresAt` nel passato) o assente.
+
+**Azione:** compilare e inviare un form di login su qualsiasi sito.
+
+**Atteso:** il banner **appare** (fail open — la verifica delle credenziali fallisce silenziosamente).
+
+---
+
+## T04 — Fail open: estensione non configurata → banner appare
+
+**Precondizione:** `baseUrl` non configurata (`await chrome.storage.sync.remove('baseUrl')`).
+
+**Azione:** compilare e inviare un form di login.
+
+**Atteso:** il banner **appare** (fail open).
+
+---
+
+## T05 — Salva da T02, poi rifare login: banner non appare più
+
+**Precondizione:** T02 completato, credenziale salvata tramite il banner.
+
+**Azione:** tornare sulla pagina di login e ripetere il login.
+
+**Atteso:** il banner **non appare** — la credenziale è ora presente nel db.

--- a/extension/TEST_PLAN_banner_no_duplicate.md
+++ b/extension/TEST_PLAN_banner_no_duplicate.md
@@ -13,41 +13,61 @@ Ogni test va eseguito almeno una volta sull'ambiente reale prima di considerare 
 
 ## T01 — Credenziale già presente: banner NON appare
 
-**Precondizione:** esiste almeno una credenziale per il dominio del sito di test (es. `localhost`).
+**Precondizione:** esiste almeno una credenziale per il dominio del sito di test.
 
 **Azione:** compilare e inviare un form di login su quel sito.
 
-**Atteso:** dopo il redirect post-login, il banner "Salva nel password manager?" **non appare**.
+**Atteso:** dopo il redirect post-login, nessun banner appare.
 
 ---
 
-## T02 — Nessuna credenziale per il dominio: banner appare
+## T02 — Nessuna credenziale per il dominio: banner salvataggio appare
 
-**Precondizione:** nessuna credenziale salvata per il dominio del sito di test.
+**Precondizione:** nessuna credenziale salvata per il dominio del sito di test; utente autenticato nell'estensione.
 
 **Azione:** compilare e inviare un form di login.
 
-**Atteso:** dopo il redirect post-login, il banner **appare** con il messaggio "Salva `<username>` nel password manager?".
+**Atteso:** dopo il redirect post-login, appare il banner "Salva `<username>` nel password manager?".
 
 ---
 
-## T03 — Fail open: token scaduto → banner appare
+## T03 — Token scaduto: banner di login appare
 
 **Precondizione:** token scaduto (`expiresAt` nel passato) o assente.
 
 **Azione:** compilare e inviare un form di login su qualsiasi sito.
 
-**Atteso:** il banner **appare** (fail open — la verifica delle credenziali fallisce silenziosamente).
+**Atteso:** appare il banner "Accedi all'estensione per salvare le credenziali su questo sito." con i pulsanti "Accedi" e "Ignora".
 
 ---
 
-## T04 — Fail open: estensione non configurata → banner appare
+## T03a — Click "Accedi" su banner di login: popup si apre
+
+**Precondizione:** banner di login visibile (da T03).
+
+**Azione:** cliccare "Accedi".
+
+**Atteso:** il banner scompare; il popup dell'estensione si apre.
+
+---
+
+## T03b — Click "Ignora" su banner di login: credenziale pendente cancellata
+
+**Precondizione:** banner di login visibile (da T03).
+
+**Azione:** cliccare "Ignora".
+
+**Atteso:** il banner scompare; navigando di nuovo sullo stesso sito il banner non riappare (credenziale pendente cancellata).
+
+---
+
+## T04 — Estensione non configurata: banner di login appare
 
 **Precondizione:** `baseUrl` non configurata (`await chrome.storage.sync.remove('baseUrl')`).
 
 **Azione:** compilare e inviare un form di login.
 
-**Atteso:** il banner **appare** (fail open).
+**Atteso:** appare il banner "Accedi all'estensione per salvare le credenziali su questo sito." (stesso comportamento di T03).
 
 ---
 
@@ -57,4 +77,14 @@ Ogni test va eseguito almeno una volta sull'ambiente reale prima di considerare 
 
 **Azione:** tornare sulla pagina di login e ripetere il login.
 
-**Atteso:** il banner **non appare** — la credenziale è ora presente nel db.
+**Atteso:** nessun banner appare.
+
+---
+
+## T06 — Dopo login via banner di autenticazione: banner salvataggio riappare
+
+**Precondizione:** T03 completato (banner di login mostrato, credenziale pendente ancora in storage); nessuna credenziale per il dominio.
+
+**Azione:** cliccare "Accedi" → effettuare il login nel popup → navigare sulla pagina originale.
+
+**Atteso:** appare il banner di salvataggio (la credenziale pendente è ancora in storage e ora l'utente è autenticato).

--- a/extension/background.js
+++ b/extension/background.js
@@ -10,7 +10,6 @@ async function handleMessage(message) {
     case 'GET_CREDENTIALS': return getCredentials(message.payload.domain);
     case 'GET_CREDENTIAL':  return getCredential(message.payload.id);
     case 'SAVE_CREDENTIAL': return saveCredential(message.payload);
-    case 'OPEN_POPUP':      return openPopup();
     default:                return { status: 'error', message: 'Unknown message type' };
   }
 }
@@ -111,15 +110,6 @@ async function getCredential(id) {
   return apiFetch(`${baseUrl}/api/credentials/${encodeURIComponent(id)}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
-}
-
-async function openPopup() {
-  try {
-    await chrome.action.openPopup();
-    return { status: 'ok' };
-  } catch (e) {
-    return { status: 'error', message: e.message };
-  }
 }
 
 async function saveCredential({ name, username, password, url }) {

--- a/extension/background.js
+++ b/extension/background.js
@@ -10,6 +10,7 @@ async function handleMessage(message) {
     case 'GET_CREDENTIALS': return getCredentials(message.payload.domain);
     case 'GET_CREDENTIAL':  return getCredential(message.payload.id);
     case 'SAVE_CREDENTIAL': return saveCredential(message.payload);
+    case 'OPEN_POPUP':      return openPopup();
     default:                return { status: 'error', message: 'Unknown message type' };
   }
 }
@@ -110,6 +111,15 @@ async function getCredential(id) {
   return apiFetch(`${baseUrl}/api/credentials/${encodeURIComponent(id)}`, {
     headers: { Authorization: `Bearer ${token}` },
   });
+}
+
+async function openPopup() {
+  try {
+    await chrome.action.openPopup();
+    return { status: 'ok' };
+  } catch (e) {
+    return { status: 'error', message: e.message };
+  }
 }
 
 async function saveCredential({ name, username, password, url }) {

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -126,18 +126,56 @@
     chrome.storage.local.remove(STORAGE_KEY);
   }
 
+  function showAuthBanner(onIgnore) {
+    removeBanner();
+
+    const banner = document.createElement('div');
+    banner.id = BANNER_ID;
+    banner.style.cssText =
+      'position:fixed;top:0;left:0;right:0;z-index:2147483647;' +
+      'background:#1e293b;color:#f8fafc;padding:12px 16px;' +
+      'display:flex;align-items:center;gap:12px;' +
+      'font-family:system-ui,sans-serif;font-size:14px;' +
+      'box-shadow:0 2px 8px rgba(0,0,0,0.35)';
+
+    const text = document.createElement('span');
+    text.style.flex = '1';
+    text.textContent = 'Accedi all\'estensione per salvare le credenziali su questo sito.';
+
+    const btnLogin = makeButton('Accedi', '#3b82f6', '#fff');
+    const btnIgnore = makeButton('Ignora', 'transparent', '#94a3b8');
+
+    btnLogin.addEventListener('click', () => {
+      removeBanner();
+      chrome.runtime.sendMessage({ type: 'OPEN_POPUP' });
+    });
+    btnIgnore.addEventListener('click', () => { removeBanner(); onIgnore(); });
+
+    banner.append(text, btnLogin, btnIgnore);
+    document.body.appendChild(banner);
+  }
+
   async function maybeShowBanner(cred) {
     if (!cred) return;
-    clearPending();
 
     try {
       const res = await chrome.runtime.sendMessage({
         type: 'GET_CREDENTIALS',
         payload: { domain: cred.name }
       });
-      if (res && res.status === 'ok' && res.data && res.data.length > 0) return;
+
+      if (res && (res.status === 'TOKEN_EXPIRED' || res.status === 'NOT_CONFIGURED')) {
+        showAuthBanner(() => clearPending());
+        return;
+      }
+
+      if (res && res.status === 'ok' && res.data && res.data.length > 0) {
+        clearPending();
+        return;
+      }
     } catch (_) {}
 
+    clearPending();
     showSaveBanner(cred, () => {
       chrome.runtime.sendMessage({ type: 'SAVE_CREDENTIAL', payload: cred });
     }, () => {});

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -126,8 +126,9 @@
     chrome.storage.local.remove(STORAGE_KEY);
   }
 
-  function showAuthBanner(onIgnore) {
+  function showAuthBanner() {
     removeBanner();
+    clearPending();
 
     const banner = document.createElement('div');
     banner.id = BANNER_ID;
@@ -142,22 +143,14 @@
     text.style.flex = '1';
     text.textContent = 'Accedi all\'estensione per salvare le credenziali su questo sito.';
 
-    const btnLogin = makeButton('Accedi', '#3b82f6', '#fff');
-    const btnIgnore = makeButton('Ignora', 'transparent', '#94a3b8');
-
-    btnLogin.addEventListener('click', () => {
-      removeBanner();
-      chrome.runtime.sendMessage({ type: 'OPEN_POPUP' });
-    });
-    btnIgnore.addEventListener('click', () => { removeBanner(); onIgnore(); });
-
-    banner.append(text, btnLogin, btnIgnore);
+    banner.append(text);
     document.body.appendChild(banner);
   }
 
   async function maybeShowBanner(cred) {
     if (!cred) return;
 
+    let authIssue = false;
     try {
       const res = await chrome.runtime.sendMessage({
         type: 'GET_CREDENTIALS',
@@ -165,15 +158,17 @@
       });
 
       if (res && (res.status === 'TOKEN_EXPIRED' || res.status === 'NOT_CONFIGURED')) {
-        showAuthBanner(() => clearPending());
-        return;
-      }
-
-      if (res && res.status === 'ok' && res.data && res.data.length > 0) {
+        authIssue = true;
+      } else if (res && res.status === 'ok' && res.data && res.data.length > 0) {
         clearPending();
         return;
       }
     } catch (_) {}
+
+    if (authIssue) {
+      showAuthBanner();
+      return;
+    }
 
     clearPending();
     showSaveBanner(cred, () => {

--- a/extension/content_script.js
+++ b/extension/content_script.js
@@ -126,9 +126,18 @@
     chrome.storage.local.remove(STORAGE_KEY);
   }
 
-  function maybeShowBanner(cred) {
+  async function maybeShowBanner(cred) {
     if (!cred) return;
     clearPending();
+
+    try {
+      const res = await chrome.runtime.sendMessage({
+        type: 'GET_CREDENTIALS',
+        payload: { domain: cred.name }
+      });
+      if (res && res.status === 'ok' && res.data && res.data.length > 0) return;
+    } catch (_) {}
+
     showSaveBanner(cred, () => {
       chrome.runtime.sendMessage({ type: 'SAVE_CREDENTIAL', payload: cred });
     }, () => {});


### PR DESCRIPTION
## Summary

- Se le credenziali per il dominio esistono già → nessun banner
- Se l'utente non è autenticato nell'estensione (`TOKEN_EXPIRED` / `NOT_CONFIGURED`) → banner informativo "Accedi all'estensione per salvare le credenziali su questo sito." senza pulsanti; la credenziale pendente viene cancellata per evitare che riappaia sulle navigazioni successive
- Se nessuna credenziale esiste e l'utente è autenticato → banner di salvataggio come prima

## Test plan manuale

| # | Precondizione | Azione | Atteso |
|---|---|---|---|
| T01 | Credenziale per il dominio già nel db | Login sul sito | Nessun banner |
| T02 | Nessuna credenziale; utente autenticato | Login sul sito | Banner salvataggio |
| T03 | Token scaduto / assente | Login sul sito | Banner informativo senza pulsanti; non riappare sulle pagine successive |
| T04 | `baseUrl` non configurata | Login sul sito | Banner informativo senza pulsanti (stesso di T03) |
| T05 | Dopo T02, credenziale salvata → rifare login | Login stesso sito | Nessun banner |

Closes #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)