### PR TITLE
chore: add AGENTS.md/CLAUDE.md context files for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# password-manager
+
+Self-hosted Rails password manager — credentials never leave the user's own server. Runs in production on a Raspberry Pi 4.
+
+## Stack
+
+Ruby 3.3.11, Rails 8, Mongoid (MongoDB ODM), Turbo + Stimulus, importmap-rails, Puma. Tests via Minitest, Capybara + Selenium for system tests.
+
+## Running everything through Docker
+
+The dev/test environment is containerized. **Never run `rails`/`bin/rails` directly on the host** — always go through `docker compose run --rm`:
+
+```bash
+# unit / integration / controller tests
+docker compose run --rm passwordmanager bundle exec rails test
+
+# system tests (Capybara + remote Selenium) — note the different service
+docker compose run --rm passwordmanager-test bundle exec rails test:system
+
+# generators and any other rails command
+docker compose run --rm passwordmanager rails generate <generator> <args>
+```
+
+`passwordmanager-test` (not `passwordmanager`) is required for system tests: it's the only service wired with `SELENIUM_REMOTE_URL` and `APP_HOST`, which `application_system_test_case.rb` needs to reach the remote Selenium container. Running system tests against `passwordmanager` fails with `Errno::ECONNREFUSED` (no local ChromeDriver in that container).
+
+Bring up dependencies first when needed: `docker compose up -d mongo` (always) and `docker compose up -d mongo selenium` (for system tests).
+
+## MongoDB version ceiling — do not propose upgrades
+
+Production hardware is a Raspberry Pi 4 (Cortex-A72, ARMv8.0-A). MongoDB ≥ 4.4.19 and all 5.0+ releases require ARMv8.2-A instructions (ATOMICS/LSE) and crash with **SIGILL** on this CPU. The maximum safe version is **MongoDB 4.4.18** — this is a hardware limit, not configurable. If a CVE or feature seems to require a newer version, flag it as blocked by hardware rather than proposing the upgrade.
+
+## Repository layout
+
+- `app/` — the Rails application (controllers, models, views, Stimulus controllers in `app/javascript`)
+- `extension/` — companion browser extension (Manifest V3, vanilla JS); see `extension/AGENTS.md` for its conventions — different stack, different testing approach
+- `docs/` — story plans and ADRs
+- `test/` — Minitest suite (`models`, `controllers`, `integration`, `system`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/extension/AGENTS.md
+++ b/extension/AGENTS.md
@@ -1,0 +1,31 @@
+# Browser extension
+
+Chrome extension (Manifest V3, plain JS — no bundler/build step) that autofills credentials from the password-manager server into web pages.
+
+## Architecture
+
+- `manifest.json` — MV3 manifest: permissions (`storage`, `tabs`, `<all_urls>`), content scripts, service worker
+- `background.js` — service worker: holds `authToken` (in `chrome.storage.local`) and `baseUrl` (in `chrome.storage.sync`), talks to the Rails API
+- `content_script.js` — injected into pages: detects login forms, autofills, shows the auth banner
+- `install_marker.js` — runs at `document_start`, marks the page as having the extension installed
+- `popup.js` / `popup.html` — toolbar popup UI (login, credential list/search, save/edit)
+- `options.js` / `options.html` — settings page (server `baseUrl`, etc.)
+
+## Manual testing — no automated test suite here
+
+This extension has **no unit/integration tests**. Verification is done through **`TEST_PLAN*.md`** documents:
+
+- Each plan must be **committed in the same commit as the production code** it covers
+- Each test case must be **run at least once against the real environment** (loaded extension + running Rails server) before the story can be considered done
+- `TEST_PLAN.md` is the main plan; `TEST_PLAN_<topic>.md` files cover specific features/regressions (e.g. `TEST_PLAN_popup.md`, `TEST_PLAN_banner_no_duplicate.md`)
+
+When changing extension behavior, update or add the relevant `TEST_PLAN*.md` rather than writing Rails/Minitest tests for it.
+
+### Loading the extension for manual testing
+
+1. `chrome://extensions` → enable "Developer mode"
+2. "Load unpacked" → select the `extension/` folder
+3. For the service worker: `chrome://extensions` → "Service Worker" link under the extension name (opens DevTools where you can inspect/seed `chrome.storage`)
+4. Have the Rails server reachable (e.g. `http://localhost:3000`) with a registered user and some saved credentials
+
+See the `## Setup comune` section of `TEST_PLAN.md` for ready-to-paste DevTools console snippets to seed/inspect `chrome.storage.sync` / `chrome.storage.local`.

--- a/extension/CLAUDE.md
+++ b/extension/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Add a root `AGENTS.md` documenting the Docker-only test/run workflow (incl. why system tests must use `passwordmanager-test`, not `passwordmanager`) and the MongoDB version ceiling imposed by the Raspberry Pi 4 production hardware (ARMv8.0-A → max MongoDB 4.4.18)
- Add `extension/AGENTS.md` documenting the browser extension's architecture and its manual `TEST_PLAN*.md` testing convention (no automated tests there)
- Symlink `CLAUDE.md` → `AGENTS.md` at both levels: Claude Code only reads `CLAUDE.md` natively (no native `AGENTS.md` support as of mid-2026 — anthropics/claude-code#34235), while `AGENTS.md` is the cross-tool open standard read by Codex/Cursor/Copilot/etc. One file on disk, two filenames, zero drift.

This consolidates knowledge that previously lived only in the assistant's external memory into the repo itself, where any agent or contributor can see it, scoped so the extension's different conventions load only when working in `extension/`.

## Test plan
- [ ] Open the repo with an AGENTS.md-aware tool and confirm the root context loads
- [ ] Confirm `CLAUDE.md` resolves correctly through the symlink (`cat CLAUDE.md`)
- [ ] Spot-check the documented commands (`docker compose run --rm passwordmanager bundle exec rails test`, `... passwordmanager-test bundle exec rails test:system`) still work as described